### PR TITLE
Add argument parsing with `argparse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,19 @@ This is a simple tool to extract .crp files for Cities: Skylines. As of right no
  * Python 2 or 3 https://www.python.org/downloads/
 
 ## Usage:
- * Run crp_extract.py. You will be prompted to type in the name of the CRP file you want to extract. Don't forget the .crp extension.
+```
+crp_extract.py [-h] [--output-dir OUTPUT_DIR] file
+
+positional arguments:
+  file                  The file to unpack
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --output-dir OUTPUT_DIR
+                        The directory to put the unpacked files into (Default:
+                        current working directory)
+```
+
  * A CRP is split up into sections, which when extracted are represented as files in the extract folder. Each section contains metadata at the beggining. When the format of the section can be determined, this metadata is moved to a file called metadata.json, and the correct file extension is added to the end of that section file. For example, if a CRP contained a section with a PNG image, then the metadata for that section would be cut and moved to metadata.json, and the smaller section file would be given a .png extension so that it functions as a PNG file.
 
 ## Key for first bytes:

--- a/crp_extract.py
+++ b/crp_extract.py
@@ -154,7 +154,7 @@ def main():
         write_file.close()
 
     #save the metadata dictionary using json
-    with open(output_path + "metadata.json", "w") as f:
+    with open(os.path.join(output_path, "metadata.json"), "w") as f:
         json.dump(metadata, f, indent=4, sort_keys=True)
 
 

--- a/formatter.py
+++ b/formatter.py
@@ -2,7 +2,11 @@ import struct
 import sys
 import time
 import os
+import os.path
 import io
+
+
+HERE = os.path.dirname(__file__)
 
 INDICES = {}
 
@@ -246,7 +250,8 @@ def get_formatted_data(bin_file, format_name, pattern_name):
 
     #this is the wrong way to open the format_file, newlines can be unexpected, user io.open()
     #format_file = open("./formats/" + format_name, "r")
-    format_file = io.open("./formats/" + format_name, "r", newline=None)
+    format_file_path = os.path.join(HERE, 'formats', format_name)
+    format_file = io.open(format_file_path, "r", newline=None)
 
     format_file.seek(0, os.SEEK_END)
     format_file_size = format_file.tell()


### PR DESCRIPTION
Add argument parsing using the `argparse` package from the Python standard library.
Add optional argument to specify output directory.
Fix hard-coded relative paths to allow execution from different working directory.